### PR TITLE
fix(workspace): member invite display and Google auth readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,10 @@ NEXT_PUBLIC_GATEWAY_URL=https://gateway.erebrus.io
 # https://dashboard.helius.dev
 NEXT_PUBLIC_HELIUS_API_KEY=
 
-# Optional social login. Unset => the Google/Apple buttons stay disabled (no
-# errors). The id must match one of the gateway's GOOGLE_CLIENT_IDS/APPLE_CLIENT_IDS.
+# Optional social login (both sides must be configured):
+# 1) Set NEXT_PUBLIC_GOOGLE_CLIENT_ID to your Google OAuth Web client ID
+# 2) Add the same ID to gateway GOOGLE_CLIENT_IDS (comma-separated if multiple)
+# 3) In Google Cloud Console → Credentials → Authorized JavaScript origins,
+#    add http://localhost:3000 and your production webapp origin
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=
 NEXT_PUBLIC_APPLE_CLIENT_ID=

--- a/src/components/v3/AuthModal.tsx
+++ b/src/components/v3/AuthModal.tsx
@@ -25,13 +25,25 @@ import {
   emailLoginVerify,
   googleLogin,
 } from "@/lib/gateway-auth";
+import { useAuthMethods } from "@/hooks/use-auth-methods";
+import axios from "axios";
 import { AccentButton, ActionButton } from "@/components/v3/ui";
 import { Input } from "@/components/ui/input";
 import { Loader2, Mail } from "lucide-react";
 import { toast } from "sonner";
 
-const GOOGLE_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
-const APPLE_CLIENT_ID = process.env.NEXT_PUBLIC_APPLE_CLIENT_ID;
+function socialLoginErrorMessage(provider: "google" | "apple", error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const body = error.response?.data as { error?: string } | undefined;
+    if (body?.error) return body.error;
+    if (error.response?.status === 503) {
+      return provider === "google"
+        ? "Google sign-in is not enabled on the gateway — add this web client ID to GOOGLE_CLIENT_IDS"
+        : "Apple sign-in is not enabled on the gateway — add your client ID to APPLE_CLIENT_IDS";
+    }
+  }
+  return provider === "google" ? "Google sign-in failed — try again" : "Apple sign-in failed — try again";
+}
 
 const AuthModalContext = createContext<{ open: () => void }>({ open: () => {} });
 
@@ -47,6 +59,8 @@ export function AuthModalProvider({ children }: { children: ReactNode }) {
   const [codeSent, setCodeSent] = useState(false);
   const [emailBusy, setEmailBusy] = useState(false);
   const [socialBusy, setSocialBusy] = useState(false);
+  const { googleClientId, appleClientId, googleEnabled, appleEnabled, emailEnabled } =
+    useAuthMethods();
 
   const completeSocialLogin = useCallback(
     async (provider: "google" | "apple", idToken: string) => {
@@ -59,12 +73,8 @@ export function AuthModalProvider({ children }: { children: ReactNode }) {
         setWebSession(session.token, session.userId, provider);
         setVisible(false);
         router.push("/dashboard");
-      } catch {
-        toast.error(
-          provider === "google"
-            ? "Google sign-in failed — try again"
-            : "Apple sign-in failed — try again"
-        );
+      } catch (error) {
+        toast.error(socialLoginErrorMessage(provider, error));
       } finally {
         setSocialBusy(false);
       }
@@ -73,12 +83,12 @@ export function AuthModalProvider({ children }: { children: ReactNode }) {
   );
 
   const { ready: googleReady, signIn: signInWithGoogle, btnRef: googleBtnRef } =
-    useGoogleSignIn(GOOGLE_CLIENT_ID, (token) => void completeSocialLogin("google", token), visible);
+    useGoogleSignIn(googleClientId, (token) => void completeSocialLogin("google", token), visible && googleEnabled);
 
   const { ready: appleReady, signIn: signInWithApple } = useAppleSignIn(
-    APPLE_CLIENT_ID,
+    appleClientId,
     (token) => void completeSocialLogin("apple", token),
-    visible
+    visible && appleEnabled
   );
 
   const handleLaunch = useCallback(async () => {
@@ -233,7 +243,7 @@ export function AuthModalProvider({ children }: { children: ReactNode }) {
                 type="button"
                 variant="neutral"
                 className="!py-2.5"
-                disabled={!GOOGLE_CLIENT_ID || !googleReady || socialBusy}
+                disabled={!googleEnabled || !googleReady || socialBusy}
                 onClick={() => {
                   if (!signInWithGoogle()) {
                     toast.error("Google sign-in is not ready yet — try again in a moment");
@@ -247,7 +257,7 @@ export function AuthModalProvider({ children }: { children: ReactNode }) {
                 type="button"
                 variant="neutral"
                 className="!py-2.5"
-                disabled={!APPLE_CLIENT_ID || !appleReady || socialBusy}
+                disabled={!appleEnabled || !appleReady || socialBusy}
                 onClick={() => {
                   void signInWithApple().then((started) => {
                     if (!started) {
@@ -265,13 +275,22 @@ export function AuthModalProvider({ children }: { children: ReactNode }) {
               className="sr-only absolute h-0 w-0 overflow-hidden"
               aria-hidden
             />
-            {(!GOOGLE_CLIENT_ID || !APPLE_CLIENT_ID) && (
+            {(!googleEnabled || !appleEnabled) && (
               <p className="text-center font-mono text-[10px] text-[var(--text-3)]">
-                {!GOOGLE_CLIENT_ID && !APPLE_CLIENT_ID
-                  ? "Google / Apple unlock once their client IDs are configured"
-                  : !GOOGLE_CLIENT_ID
-                    ? "Google unlocks once NEXT_PUBLIC_GOOGLE_CLIENT_ID is configured"
-                    : "Apple unlocks once NEXT_PUBLIC_APPLE_CLIENT_ID is configured"}
+                {!googleClientId && !appleClientId
+                  ? "Set NEXT_PUBLIC_GOOGLE_CLIENT_ID / NEXT_PUBLIC_APPLE_CLIENT_ID in the webapp, and matching GOOGLE_CLIENT_IDS / APPLE_CLIENT_IDS on the gateway"
+                  : !googleEnabled && googleClientId
+                    ? "Google: add this web client ID to gateway GOOGLE_CLIENT_IDS and authorized origins in Google Cloud Console"
+                    : !appleEnabled && appleClientId
+                      ? "Apple: add this client ID to gateway APPLE_CLIENT_IDS"
+                      : !googleClientId
+                        ? "Google unlocks once NEXT_PUBLIC_GOOGLE_CLIENT_ID is configured"
+                        : "Apple unlocks once NEXT_PUBLIC_APPLE_CLIENT_ID is configured"}
+              </p>
+            )}
+            {!emailEnabled && (
+              <p className="text-center font-mono text-[10px] text-[var(--text-3)]">
+                Email sign-in requires RESEND_API_KEY on the gateway
               </p>
             )}
           </div>

--- a/src/components/v3/workspace/OrgDetailPanel.tsx
+++ b/src/components/v3/workspace/OrgDetailPanel.tsx
@@ -28,6 +28,11 @@ import {
   GatewayApiError,
 } from "@/lib/gateway/client";
 import { memberRoleLabel, memberStatusLabel } from "@/lib/gateway/member-labels";
+import {
+  memberPrimaryLabel,
+  memberSecondaryLabel,
+  visiblePendingInvites,
+} from "@/lib/gateway/member-display";
 import type {
   GatewayApiKey,
   GatewayOrg,
@@ -275,6 +280,7 @@ export function OrgDetailPanel({ orgId }: { orgId: string }) {
 
   const online = nodes.filter((n) => n.status === "active" || n.status === "online").length;
   const selectedNode = nodes.find((n) => n.node_id === selectedNodeId) ?? null;
+  const displayedPendingInvites = visiblePendingInvites(members, pendingInvites);
 
   return (
     <div className="grid gap-6 lg:grid-cols-[minmax(0,17rem)_1fr] lg:items-start">
@@ -334,7 +340,7 @@ export function OrgDetailPanel({ orgId }: { orgId: string }) {
         <div className="flex-1">
           <h2 className="text-2xl font-bold tracking-tight">{org.name}</h2>
           <p className="text-sm text-[var(--text-3)]">
-            {org.plan ?? org.kind} · {members.length + pendingInvites.length} members · {nodes.length} nodes
+            {org.plan ?? org.kind} · {members.length + displayedPendingInvites.length} members · {nodes.length} nodes
             {entitlements ? ` · ${entitlements.shield_instances_included} Shield · ${entitlements.sentinel_licenses_included} Sentinel` : ""}
           </p>
         </div>
@@ -353,7 +359,7 @@ export function OrgDetailPanel({ orgId }: { orgId: string }) {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
         <StatCard label="Nodes online" value={online} />
         <StatCard label="Total nodes" value={nodes.length} />
-        <StatCard label="Members" value={members.length + pendingInvites.length} />
+        <StatCard label="Members" value={members.length + displayedPendingInvites.length} />
         <StatCard label="Seats (VPN)" value={planSeatTier ? `${seatsUsed}/${seatsIncluded}` : "—"} />
         <StatCard label="VPN clients" value={clients.length} />
         <StatCard label="API calls (30d)" value={usage.api_calls ?? "—"} />
@@ -572,7 +578,7 @@ export function OrgDetailPanel({ orgId }: { orgId: string }) {
             </Card>
           )}
           <Card className="overflow-hidden">
-            {members.length === 0 && pendingInvites.length === 0 ? (
+            {members.length === 0 && displayedPendingInvites.length === 0 ? (
               <p className="px-5 py-8 text-sm text-[var(--text-2)]">No members yet.</p>
             ) : (
               <>
@@ -582,11 +588,12 @@ export function OrgDetailPanel({ orgId }: { orgId: string }) {
                     className="flex flex-col gap-3 border-b border-white/[0.04] px-5 py-3 sm:flex-row sm:items-center sm:justify-between"
                   >
                     <div>
-                      <div className="font-mono text-sm">
-                        {m.wallet_address
-                          ? `${m.wallet_address.slice(0, 8)}…${m.wallet_address.slice(-6)}`
-                          : m.email ?? "Member"}
-                      </div>
+                      <div className="text-sm font-medium">{memberPrimaryLabel(m)}</div>
+                      {memberSecondaryLabel(m) && (
+                        <div className="font-mono text-[11px] text-[var(--text-3)]">
+                          {memberSecondaryLabel(m)}
+                        </div>
+                      )}
                       <MonoLabel>
                         {memberRoleLabel(m.role)}
                         {m.seat_tier && m.seat_tier !== "free" ? ` · ${m.seat_tier} seat` : ""}
@@ -675,7 +682,7 @@ export function OrgDetailPanel({ orgId }: { orgId: string }) {
                     </div>
                   </div>
                 ))}
-                {pendingInvites.map((inv) => (
+                {displayedPendingInvites.map((inv) => (
                   <div
                     key={inv.id}
                     className="flex flex-col gap-2 border-b border-white/[0.04] px-5 py-3 sm:flex-row sm:items-center sm:justify-between"

--- a/src/hooks/use-auth-methods.ts
+++ b/src/hooks/use-auth-methods.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchAuthMethods, type AuthMethods } from "@/lib/gateway-auth";
+
+const DEFAULT_METHODS: AuthMethods = {
+  wallet: true,
+  email: false,
+  google: false,
+  apple: false,
+};
+
+export function useAuthMethods() {
+  const [methods, setMethods] = useState<AuthMethods | null>(null);
+
+  useEffect(() => {
+    fetchAuthMethods()
+      .then(setMethods)
+      .catch(() => setMethods(DEFAULT_METHODS));
+  }, []);
+
+  const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID?.trim();
+  const appleClientId = process.env.NEXT_PUBLIC_APPLE_CLIENT_ID?.trim();
+  const resolved = methods ?? DEFAULT_METHODS;
+
+  return {
+    methods: resolved,
+    loading: methods === null,
+    googleClientId,
+    appleClientId,
+    googleEnabled: Boolean(googleClientId && resolved.google),
+    appleEnabled: Boolean(appleClientId && resolved.apple),
+    emailEnabled: resolved.email,
+  };
+}

--- a/src/lib/gateway-auth.ts
+++ b/src/lib/gateway-auth.ts
@@ -110,6 +110,25 @@ export async function emailLoginVerify(email: string, code: string): Promise<Aut
   return parseSession(data);
 }
 
+export type AuthMethods = {
+  wallet: boolean;
+  email: boolean;
+  google: boolean;
+  apple: boolean;
+};
+
+/** Reports which login methods the gateway has configured. */
+export async function fetchAuthMethods(): Promise<AuthMethods> {
+  const { data } = await axios.get(gatewayAuthUrl("auth/methods"));
+  const d = (data ?? {}) as Record<string, unknown>;
+  return {
+    wallet: d.wallet !== false,
+    email: d.email === true,
+    google: d.google === true,
+    apple: d.apple === true,
+  };
+}
+
 /** Exchanges a Google ID token for a session. */
 export async function googleLogin(idToken: string): Promise<AuthSession> {
   const { data } = await axios.post(gatewayAuthUrl("auth/google"), { id_token: idToken });

--- a/src/lib/gateway/member-display.ts
+++ b/src/lib/gateway/member-display.ts
@@ -1,0 +1,32 @@
+import type { GatewayOrgInvite, GatewayOrgMember } from "./types";
+
+export function memberPrimaryLabel(member: GatewayOrgMember): string {
+  if (member.name?.trim()) return member.name.trim();
+  if (member.email?.trim()) return member.email.trim();
+  if (member.wallet_address?.trim()) {
+    const w = member.wallet_address;
+    return w.length > 16 ? `${w.slice(0, 8)}…${w.slice(-6)}` : w;
+  }
+  return "Member";
+}
+
+export function memberSecondaryLabel(member: GatewayOrgMember): string | null {
+  if (member.wallet_address?.trim() && member.email?.trim()) {
+    const w = member.wallet_address;
+    return w.length > 16 ? `${w.slice(0, 8)}…${w.slice(-6)}` : w;
+  }
+  return null;
+}
+
+/** Hide pending email invites that already have a membership row for the same address. */
+export function visiblePendingInvites(
+  members: GatewayOrgMember[],
+  invites: GatewayOrgInvite[]
+): GatewayOrgInvite[] {
+  const memberEmails = new Set(
+    members
+      .map((m) => m.email?.trim().toLowerCase())
+      .filter((e): e is string => Boolean(e))
+  );
+  return invites.filter((inv) => !memberEmails.has(inv.email.trim().toLowerCase()));
+}

--- a/src/lib/gateway/member-labels.ts
+++ b/src/lib/gateway/member-labels.ts
@@ -14,9 +14,8 @@ export function memberRoleLabel(role: OrgMemberRole | string | undefined): strin
 }
 
 export function memberStatusLabel(status: string | undefined): string {
-  if (!status) return "Active";
-  if (status === "invited") return "Invite pending";
+  if (!status || status === "active") return "Active";
+  if (status === "invited") return "Invite pending — awaiting first sign-in";
   if (status === "pending") return "Awaiting sign-in";
-  if (status === "active") return "Active";
   return status;
 }


### PR DESCRIPTION
Dedupe pending email invites in the member list, show email/name from the gateway, and gate Google sign-in on both webapp client ID and gateway GOOGLE_CLIENT_IDS via GET /auth/methods with clearer setup hints.