### PR TITLE
feat(notifications): rich invite previews and detail modal with actions

### DIFF
--- a/src/app/(app)/notifications/invite/[orgId]/page.tsx
+++ b/src/app/(app)/notifications/invite/[orgId]/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { fetchAccountOrgInvite } from "@/lib/gateway/client";
+import type { GatewayUserOrgInvite } from "@/lib/gateway/types";
+import { OrgInviteDetailPanel } from "@/components/v3/app/OrgInviteDetailPanel";
+import { Card } from "@/components/v3/ui";
+
+export default function OrgInviteNotificationPage() {
+  const params = useParams<{ orgId: string }>();
+  const orgId = params.orgId;
+  const [invite, setInvite] = useState<GatewayUserOrgInvite | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!orgId) return;
+    fetchAccountOrgInvite(orgId)
+      .then(setInvite)
+      .catch(() => setError("This invitation is no longer available."));
+  }, [orgId]);
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4">
+      <Link href="/workspace" className="inline-flex text-sm text-[var(--text-2)] hover:text-[var(--text)]">
+        ← Back to workspaces
+      </Link>
+
+      <Card className="p-6">
+        {error ? (
+          <p className="text-sm text-[var(--text-2)]">{error}</p>
+        ) : invite ? (
+          <OrgInviteDetailPanel invite={invite} />
+        ) : (
+          <p className="text-sm text-[var(--text-3)]">Loading invitation…</p>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/components/v3/app/NotificationBell.tsx
+++ b/src/components/v3/app/NotificationBell.tsx
@@ -1,36 +1,34 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 import { Bell } from "lucide-react";
 import {
-  acceptAccountOrgInvite,
-  declineAccountOrgInvite,
-  fetchAccountOrgInvites,
-  GatewayApiError,
-} from "@/lib/gateway/client";
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { fetchAccountOrgInvites } from "@/lib/gateway/client";
 import type { GatewayUserOrgInvite } from "@/lib/gateway/types";
-import { memberRoleLabel } from "@/lib/gateway/member-labels";
 import {
   countUnread,
   inviteNotificationId,
-  markNotificationRead,
   markNotificationsRead,
 } from "@/lib/notifications";
-import { ActionButton, iconButtonClass } from "@/components/v3/ui";
+import { invitePreviewLine, invitePreviewSubline } from "@/lib/invite-notifications";
+import { OrgInviteDetailPanel } from "@/components/v3/app/OrgInviteDetailPanel";
+import { iconButtonClass } from "@/components/v3/ui";
 import { cn } from "@/lib/utils";
-import { toast } from "sonner";
 
 export function NotificationBell() {
-  const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [detailInvite, setDetailInvite] = useState<GatewayUserOrgInvite | null>(null);
   const [invites, setInvites] = useState<GatewayUserOrgInvite[]>([]);
   const [loading, setLoading] = useState(false);
   const [readTick, setReadTick] = useState(0);
 
   const notificationIds = invites.map((inv) => inviteNotificationId(inv.org_id));
   const unreadCount = countUnread(notificationIds);
-  // readTick forces re-render after localStorage updates
   void readTick;
 
   const reload = useCallback(() => {
@@ -59,100 +57,86 @@ export function NotificationBell() {
     }
   };
 
-  const acceptInvite = async (inv: GatewayUserOrgInvite) => {
-    try {
-      await acceptAccountOrgInvite(inv.org_id);
-      markNotificationRead(inviteNotificationId(inv.org_id));
-      toast.success(`Joined ${inv.org_name}`);
-      setInvites((prev) => prev.filter((i) => i.org_id !== inv.org_id));
-      setOpen(false);
-      router.push(`/workspace/${inv.org_id}`);
-    } catch (e) {
-      toast.error(e instanceof GatewayApiError ? e.message : "Failed to join workspace");
-    }
-  };
-
-  const declineInvite = async (inv: GatewayUserOrgInvite) => {
-    try {
-      await declineAccountOrgInvite(inv.org_id);
-      markNotificationRead(inviteNotificationId(inv.org_id));
-      toast.message(`Declined invite to ${inv.org_name}`);
-      setInvites((prev) => prev.filter((i) => i.org_id !== inv.org_id));
-    } catch (e) {
-      toast.error(e instanceof GatewayApiError ? e.message : "Failed to decline invite");
-    }
+  const openDetail = (inv: GatewayUserOrgInvite) => {
+    setDetailInvite(inv);
+    setOpen(false);
   };
 
   return (
-    <div className="relative">
-      <button
-        type="button"
-        onClick={handleOpen}
-        className={cn(iconButtonClass, "relative")}
-        aria-label={unreadCount > 0 ? `${unreadCount} unread notifications` : "Notifications"}
-      >
-        <Bell size={18} />
-        {unreadCount > 0 && (
-          <span className="absolute -right-0.5 -top-0.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[var(--accent)] px-1 text-[10px] font-bold text-[var(--on-accent)]">
-            {unreadCount > 9 ? "9+" : unreadCount}
-          </span>
-        )}
-      </button>
+    <>
+      <div className="relative">
+        <button
+          type="button"
+          onClick={handleOpen}
+          className={cn(iconButtonClass, "relative")}
+          aria-label={unreadCount > 0 ? `${unreadCount} unread notifications` : "Notifications"}
+        >
+          <Bell size={18} />
+          {unreadCount > 0 && (
+            <span className="absolute -right-0.5 -top-0.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[var(--accent)] px-1 text-[10px] font-bold text-[var(--on-accent)]">
+              {unreadCount > 9 ? "9+" : unreadCount}
+            </span>
+          )}
+        </button>
 
-      {open && (
-        <>
-          <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
-          <div className="absolute right-0 top-12 z-40 w-[min(92vw,340px)] rounded-[14px] border border-white/10 bg-[#14110F] shadow-[0_24px_60px_rgba(0,0,0,0.6)]">
-            <div className="border-b border-white/[0.06] px-4 py-3">
-              <div className="text-sm font-semibold">Notifications</div>
-              <p className="mt-0.5 text-xs text-[var(--text-3)]">
-                Workspace invitations and updates
-              </p>
-            </div>
-
-            <div className="max-h-[min(60vh,420px)] overflow-y-auto p-2">
-              {loading && invites.length === 0 ? (
-                <p className="px-3 py-6 text-center text-sm text-[var(--text-3)]">Loading…</p>
-              ) : invites.length === 0 ? (
-                <p className="px-3 py-6 text-center text-sm text-[var(--text-2)]">
-                  No pending notifications
+        {open && (
+          <>
+            <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
+            <div className="absolute right-0 top-12 z-40 w-[min(92vw,380px)] rounded-[14px] border border-white/10 bg-[#14110F] shadow-[0_24px_60px_rgba(0,0,0,0.6)]">
+              <div className="border-b border-white/[0.06] px-4 py-3">
+                <div className="text-sm font-semibold">Notifications</div>
+                <p className="mt-0.5 text-xs text-[var(--text-3)]">
+                  Tap an invite for full details and actions
                 </p>
-              ) : (
-                invites.map((inv) => (
-                  <div
-                    key={inv.id}
-                    className="mb-1 rounded-xl border border-white/[0.06] bg-white/[0.02] p-3"
-                  >
-                    <div className="text-sm font-medium">{inv.org_name}</div>
-                    <p className="mt-1 text-xs leading-relaxed text-[var(--text-2)]">
-                      You&apos;ve been invited as{" "}
-                      <span className="text-[var(--text)]">{memberRoleLabel(inv.role)}</span>
-                      {inv.source === "email" ? " via email" : ""}.
-                    </p>
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      <ActionButton
-                        type="button"
-                        variant="accent"
-                        className="!px-3 !py-1.5 !text-xs"
-                        onClick={() => acceptInvite(inv)}
-                      >
-                        Join
-                      </ActionButton>
-                      <ActionButton
-                        type="button"
-                        className="!px-3 !py-1.5 !text-xs"
-                        onClick={() => declineInvite(inv)}
-                      >
-                        Decline
-                      </ActionButton>
-                    </div>
-                  </div>
-                ))
-              )}
+              </div>
+
+              <div className="max-h-[min(60vh,420px)] overflow-y-auto p-2">
+                {loading && invites.length === 0 ? (
+                  <p className="px-3 py-6 text-center text-sm text-[var(--text-3)]">Loading…</p>
+                ) : invites.length === 0 ? (
+                  <p className="px-3 py-6 text-center text-sm text-[var(--text-2)]">
+                    No pending notifications
+                  </p>
+                ) : (
+                  invites.map((inv) => (
+                    <button
+                      key={inv.id}
+                      type="button"
+                      onClick={() => openDetail(inv)}
+                      className="mb-1 w-full rounded-xl border border-white/[0.06] bg-white/[0.02] p-3 text-left transition-colors hover:border-[var(--accent)]/25 hover:bg-white/[0.04]"
+                    >
+                      <div className="text-sm font-semibold leading-snug">
+                        {invitePreviewLine(inv)}
+                      </div>
+                      <p className="mt-1.5 text-xs leading-relaxed text-[var(--text-3)]">
+                        {invitePreviewSubline(inv)}
+                      </p>
+                    </button>
+                  ))
+                )}
+              </div>
             </div>
-          </div>
-        </>
-      )}
-    </div>
+          </>
+        )}
+      </div>
+
+      <Dialog open={!!detailInvite} onOpenChange={(v) => !v && setDetailInvite(null)}>
+        <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto border-white/10 bg-[var(--elevated)] text-[var(--text)]">
+          <DialogHeader>
+            <DialogTitle className="sr-only">Workspace invitation</DialogTitle>
+          </DialogHeader>
+          {detailInvite && (
+            <OrgInviteDetailPanel
+              invite={detailInvite}
+              onClose={() => setDetailInvite(null)}
+              onResolved={() => {
+                reload();
+                setDetailInvite(null);
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/components/v3/app/OrgInviteDetailPanel.tsx
+++ b/src/components/v3/app/OrgInviteDetailPanel.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import {
+  acceptAccountOrgInvite,
+  declineAccountOrgInvite,
+  GatewayApiError,
+} from "@/lib/gateway/client";
+import type { GatewayUserOrgInvite } from "@/lib/gateway/types";
+import { memberRoleLabel } from "@/lib/gateway/member-labels";
+import {
+  formatInviteDate,
+  inviteOrgTitle,
+  invitePreviewSubline,
+} from "@/lib/invite-notifications";
+import { inviteNotificationId, markNotificationRead } from "@/lib/notifications";
+import { orgPlanLabel } from "@/lib/org-plans";
+import { AccentButton, ActionButton, Card, MonoLabel } from "@/components/v3/ui";
+import { toast } from "sonner";
+
+export function OrgInviteDetailPanel({
+  invite,
+  onClose,
+  onResolved,
+}: {
+  invite: GatewayUserOrgInvite;
+  onClose?: () => void;
+  onResolved?: () => void;
+}) {
+  const router = useRouter();
+  const title = inviteOrgTitle(invite);
+  const [busy, setBusy] = useState(false);
+
+  const accept = async () => {
+    setBusy(true);
+    try {
+      await acceptAccountOrgInvite(invite.org_id);
+      markNotificationRead(inviteNotificationId(invite.org_id));
+      toast.success(`Joined ${title}`);
+      onResolved?.();
+      onClose?.();
+      router.push(`/workspace/${invite.org_id}`);
+    } catch (e) {
+      toast.error(e instanceof GatewayApiError ? e.message : "Failed to join workspace");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const decline = async () => {
+    setBusy(true);
+    try {
+      await declineAccountOrgInvite(invite.org_id);
+      markNotificationRead(inviteNotificationId(invite.org_id));
+      toast.message(`Declined invite to ${title}`);
+      onResolved?.();
+      onClose?.();
+    } catch (e) {
+      toast.error(e instanceof GatewayApiError ? e.message : "Failed to decline invite");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-start gap-4">
+        {invite.org_logo_url ? (
+          <Image
+            src={invite.org_logo_url}
+            alt=""
+            width={64}
+            height={64}
+            unoptimized
+            className="h-16 w-16 rounded-2xl border border-white/10 object-cover"
+          />
+        ) : (
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-[var(--solana)] to-[var(--accent)] text-2xl font-bold">
+            {title.charAt(0).toUpperCase()}
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <MonoLabel>Workspace invitation</MonoLabel>
+          <h2 className="mt-1 text-xl font-bold tracking-tight">{title}</h2>
+          {invite.org_name !== title && (
+            <p className="mt-0.5 text-sm text-[var(--text-3)]">{invite.org_name}</p>
+          )}
+          <p className="mt-2 text-sm text-[var(--text-2)]">{invitePreviewSubline(invite)}</p>
+        </div>
+      </div>
+
+      <Card className="grid gap-3 p-4 sm:grid-cols-2">
+        <DetailItem label="Your role" value={memberRoleLabel(invite.role)} />
+        <DetailItem
+          label="Plan"
+          value={invite.org_plan ? orgPlanLabel(invite.org_plan) : "Workspace"}
+        />
+        <DetailItem label="Team size" value={`${invite.member_count ?? 0} members`} />
+        <DetailItem label="Nodes" value={`${invite.node_count ?? 0} enrolled`} />
+        {invite.seat_tier && invite.seat_tier !== "free" && (
+          <DetailItem label="VPN seat" value={invite.seat_tier} />
+        )}
+        {invite.invited_by_name && (
+          <DetailItem label="Invited by" value={invite.invited_by_name} />
+        )}
+        <DetailItem
+          label="Sent"
+          value={formatInviteDate(invite.created_at)}
+          className="sm:col-span-2"
+        />
+      </Card>
+
+      {invite.org_description?.trim() && (
+        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+          <MonoLabel>About this workspace</MonoLabel>
+          <p className="mt-2 text-sm leading-relaxed text-[var(--text-2)]">
+            {invite.org_description.trim()}
+          </p>
+        </div>
+      )}
+
+      <div className="rounded-xl border border-white/[0.06] bg-[var(--accent)]/5 px-4 py-3 text-sm leading-relaxed text-[var(--text-2)]">
+        Accepting adds you to <span className="text-[var(--text)]">{title}</span> with{" "}
+        <span className="text-[var(--text)]">{memberRoleLabel(invite.role)}</span> access.
+        Declining notifies the workspace team and removes this invite.
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <AccentButton type="button" onClick={accept} disabled={busy}>
+          Accept & join workspace
+        </AccentButton>
+        <ActionButton type="button" variant="danger" onClick={decline} disabled={busy}>
+          Decline invitation
+        </ActionButton>
+        {onClose && (
+          <ActionButton type="button" onClick={onClose} disabled={busy}>
+            Close
+          </ActionButton>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DetailItem({
+  label,
+  value,
+  className,
+}: {
+  label: string;
+  value: string;
+  className?: string;
+}) {
+  return (
+    <div className={className}>
+      <div className="font-mono text-[10px] uppercase tracking-wide text-[var(--text-3)]">
+        {label}
+      </div>
+      <div className="mt-1 text-sm font-medium text-[var(--text)]">{value}</div>
+    </div>
+  );
+}

--- a/src/lib/gateway/client.ts
+++ b/src/lib/gateway/client.ts
@@ -218,6 +218,10 @@ export async function fetchAccountOrgInvites(): Promise<GatewayUserOrgInvite[]> 
   return Array.isArray(data) ? (data as GatewayUserOrgInvite[]) : [];
 }
 
+export async function fetchAccountOrgInvite(orgId: string): Promise<GatewayUserOrgInvite> {
+  return gatewayFetch(`account/org-invites/${orgId}`);
+}
+
 export async function acceptAccountOrgInvite(orgId: string): Promise<void> {
   await gatewayFetch(`account/org-invites/${orgId}/accept`, { method: "POST" });
 }

--- a/src/lib/gateway/types.ts
+++ b/src/lib/gateway/types.ts
@@ -241,9 +241,19 @@ export interface GatewayUserOrgInvite {
   org_id: string;
   org_name: string;
   org_slug?: string;
+  org_display_name?: string;
+  org_plan?: string;
+  org_description?: string;
+  org_logo_url?: string;
+  member_count?: number;
+  node_count?: number;
   role: string;
   seat_tier?: string;
   source: "membership" | "email" | string;
+  invite_channel?: "wallet" | "email" | string;
+  invited_by_id?: string;
+  invited_by_name?: string;
+  invited_by_email?: string;
   created_at: string;
 }
 

--- a/src/lib/invite-notifications.ts
+++ b/src/lib/invite-notifications.ts
@@ -1,0 +1,43 @@
+import { memberRoleLabel } from "@/lib/gateway/member-labels";
+import { orgPlanLabel } from "@/lib/org-plans";
+import type { GatewayUserOrgInvite } from "@/lib/gateway/types";
+
+export function inviteOrgTitle(inv: GatewayUserOrgInvite): string {
+  return inv.org_display_name?.trim() || inv.org_name;
+}
+
+export function invitePreviewLine(inv: GatewayUserOrgInvite): string {
+  const title = inviteOrgTitle(inv);
+  const role = memberRoleLabel(inv.role);
+  const plan = inv.org_plan ? orgPlanLabel(inv.org_plan) : null;
+  const inviter = inv.invited_by_name?.trim();
+  const parts = [
+    `${title} · ${role}`,
+    plan,
+    inv.member_count != null ? `${inv.member_count} members` : null,
+    inviter ? `from ${inviter}` : null,
+  ].filter(Boolean);
+  return parts.join(" · ");
+}
+
+export function invitePreviewSubline(inv: GatewayUserOrgInvite): string {
+  const bits: string[] = [];
+  if (inv.invite_channel === "email") bits.push("Email invite");
+  else if (inv.invite_channel === "wallet") bits.push("Wallet invite");
+  if (inv.seat_tier && inv.seat_tier !== "free") bits.push(`${inv.seat_tier} VPN seat`);
+  if (inv.node_count != null) bits.push(`${inv.node_count} nodes`);
+  if (inv.org_slug) bits.push(`@${inv.org_slug}`);
+  return bits.join(" · ") || "Workspace invitation";
+}
+
+export function formatInviteDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("en", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}


### PR DESCRIPTION
Show concise multi-field invite summaries in the bell list, open a full detail modal on click with role/plan/team context, and add /notifications/invite/[orgId] for direct links from email.