### PR TITLE
fix(workspace): open invited orgs and surface access errors

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -119,7 +119,7 @@ export default function DashboardPage() {
             orgs.slice(0, 3).map((org) => (
               <Link
                 key={org.id}
-                href={`/workspace/${org.id}`}
+                href={org.id ? `/workspace/${org.id}` : "/workspace"}
                 className="flex items-center gap-3.5 border-b border-white/[0.04] px-5 py-4 transition-colors hover:bg-white/[0.02]"
               >
                 <div

--- a/src/app/(app)/workspace/page.tsx
+++ b/src/app/(app)/workspace/page.tsx
@@ -184,7 +184,7 @@ export default function WorkspacePage() {
       )}
 
       <div className="grid gap-4 md:grid-cols-2">
-        {orgs.map((org) => (
+        {orgs.filter((org) => org.id).map((org) => (
           <Link key={org.id} href={`/workspace/${org.id}`}>
             <Card className="h-full p-5 transition-colors hover:border-[var(--accent)]/25">
               <div className="mb-4 flex items-center gap-3.5">
@@ -224,7 +224,7 @@ export default function WorkspacePage() {
         ))}
       </div>
 
-      {orgs.length === 0 && (
+      {orgs.filter((org) => org.id).length === 0 && (
         <Card className="p-10 text-center text-[var(--text-2)]">
           No workspaces yet. Create one to start operating nodes.
         </Card>

--- a/src/components/v3/app/RequireAuth.tsx
+++ b/src/components/v3/app/RequireAuth.tsx
@@ -31,7 +31,7 @@ export function RequireAuth({ children }: { children: ReactNode }) {
         <div className="mx-auto max-w-md py-20 text-center">
           <h2 className="text-2xl font-bold tracking-tight">Connect to continue</h2>
           <p className="mt-3 text-sm text-[var(--text-2)]">
-            Sign in with your wallet to access the Erebrus app.
+            Sign in with your wallet, email, Google, or Apple to access the Erebrus app.
           </p>
           <div className="mt-6 flex flex-col gap-3">
             <AuthModalTrigger>

--- a/src/components/v3/workspace/OrgDetailPanel.tsx
+++ b/src/components/v3/workspace/OrgDetailPanel.tsx
@@ -118,6 +118,8 @@ export function OrgDetailPanel({ orgId }: { orgId: string }) {
   const [tokenCopied, setTokenCopied] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteConfirmName, setDeleteConfirmName] = useState("");
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
   const isPrivileged = org?.role === "owner" || org?.role === "admin";
   const isOwner = org?.role === "owner";
@@ -158,44 +160,58 @@ export function OrgDetailPanel({ orgId }: { orgId: string }) {
   };
 
   const reload = () => {
-    fetchOrg(orgId).then((o) => {
-      const privileged = o.role === "owner" || o.role === "admin";
-      return Promise.all([
-        Promise.resolve(o),
-        fetchOrgNodes(orgId).catch(() => []),
-        fetchOrgMembers(orgId).catch(() => []),
-        privileged ? fetchOrgInvites(orgId).catch(() => []) : Promise.resolve([]),
-        privileged ? fetchOrgApiKeys(orgId).catch(() => []) : Promise.resolve([]),
-        fetchOrgUsage(orgId).catch(() => ({})),
-        fetchOrgClients(orgId).catch(() => []),
-        fetchOrgEntitlements(orgId).catch(() => null),
-        privileged ? fetchOrgProfile(orgId).catch(() => null) : Promise.resolve(null),
-      ]).then(([orgData, n, m, invites, keys, u, c, ent, profile]) => {
-        setOrg(orgData);
-        setEditName(orgData.name);
-        setEditSlug(orgData.slug ?? "");
-        setEditPublicProfile(orgData.public_profile_enabled ?? false);
-        if (profile) {
-          setOrgProfile(profile);
-          setEditDisplayName(profile.display_name ?? "");
-          setEditDescription(profile.description ?? "");
-          setEditWebsite(profile.website_url ?? "");
-          setEditLogoUrl(profile.logo_url ?? "");
-          setEditPublicEmail(profile.public_email ?? "");
-          setEditCountry(profile.country ?? "");
-        }
-        setNodes(n);
-        setMembers(m);
-        setPendingInvites(invites as GatewayOrgInvite[]);
-        setApiKeys(keys as GatewayApiKey[]);
-        setUsage(u as Record<string, number>);
-        setClients(c as GatewayVpnClient[]);
-        setEntitlements(ent);
-        if (n.length > 0) {
-          void loadNodeServices(n);
-        }
-      });
-    });
+    setLoading(true);
+    setLoadError(null);
+    fetchOrg(orgId)
+      .then((o) => {
+        const privileged = o.role === "owner" || o.role === "admin";
+        return Promise.all([
+          Promise.resolve(o),
+          fetchOrgNodes(orgId).catch(() => []),
+          fetchOrgMembers(orgId).catch(() => []),
+          privileged ? fetchOrgInvites(orgId).catch(() => []) : Promise.resolve([]),
+          privileged ? fetchOrgApiKeys(orgId).catch(() => []) : Promise.resolve([]),
+          fetchOrgUsage(orgId).catch(() => ({})),
+          fetchOrgClients(orgId).catch(() => []),
+          fetchOrgEntitlements(orgId).catch(() => null),
+          privileged ? fetchOrgProfile(orgId).catch(() => null) : Promise.resolve(null),
+        ]).then(([orgData, n, m, invites, keys, u, c, ent, profile]) => {
+          setOrg(orgData);
+          setEditName(orgData.name);
+          setEditSlug(orgData.slug ?? "");
+          setEditPublicProfile(orgData.public_profile_enabled ?? false);
+          if (profile) {
+            setOrgProfile(profile);
+            setEditDisplayName(profile.display_name ?? "");
+            setEditDescription(profile.description ?? "");
+            setEditWebsite(profile.website_url ?? "");
+            setEditLogoUrl(profile.logo_url ?? "");
+            setEditPublicEmail(profile.public_email ?? "");
+            setEditCountry(profile.country ?? "");
+          }
+          setNodes(n);
+          setMembers(m);
+          setPendingInvites(invites as GatewayOrgInvite[]);
+          setApiKeys(keys as GatewayApiKey[]);
+          setUsage(u as Record<string, number>);
+          setClients(c as GatewayVpnClient[]);
+          setEntitlements(ent);
+          if (n.length > 0) {
+            void loadNodeServices(n);
+          }
+        });
+      })
+      .catch((e) => {
+        setOrg(null);
+        const message =
+          e instanceof GatewayApiError
+            ? e.status === 403
+              ? "You don't have access to this workspace. Accept the invite with the same account you signed in with, or ask the owner to re-invite you."
+              : e.message
+            : "Could not load this workspace";
+        setLoadError(message);
+      })
+      .finally(() => setLoading(false));
   };
 
   useEffect(() => {
@@ -318,8 +334,25 @@ export function OrgDetailPanel({ orgId }: { orgId: string }) {
     }
   };
 
-  if (!org) {
+  if (loading && !org) {
     return <div className="py-20 text-center text-[var(--text-2)]">Loading workspace…</div>;
+  }
+
+  if (loadError || !org) {
+    return (
+      <div className="mx-auto max-w-lg py-20 text-center">
+        <h2 className="text-xl font-bold tracking-tight">Workspace unavailable</h2>
+        <p className="mt-3 text-sm text-[var(--text-2)]">
+          {loadError ?? "This workspace could not be loaded."}
+        </p>
+        <Link
+          href="/workspace"
+          className="mt-6 inline-flex text-sm font-semibold text-[var(--accent-hi)]"
+        >
+          ← Back to workspaces
+        </Link>
+      </div>
+    );
   }
 
   const online = nodes.filter((n) => n.status === "active" || n.status === "online").length;

--- a/src/components/v3/workspace/OrgJoinPanel.tsx
+++ b/src/components/v3/workspace/OrgJoinPanel.tsx
@@ -73,7 +73,7 @@ export function OrgJoinPanel({ slug }: { slug: string }) {
     const orgs = await fetchOrgs().catch(() => []);
     const joined = orgs.find((o) => o.id === preview.org_id || o.slug === preview.slug);
     if (joined) {
-      await redirectToWorkspace(joined.id);
+      await redirectToWorkspace(joined.id || preview.org_id);
       return true;
     }
     try {


### PR DESCRIPTION
Filter workspace links to orgs with ids, show clear 403 messaging on detail load failure, and fall back to invite org_id on join redirect.