### PR TITLE
Revert public latency display from public pages

### DIFF
--- a/src/components/v3/app/NodeDetailPanel.tsx
+++ b/src/components/v3/app/NodeDetailPanel.tsx
@@ -86,6 +86,7 @@ export function NodeDetailPanel({
   onUse,
   onClose,
   showAction = true,
+  showLatency = true,
 }: {
   node: GatewayNode;
   /** Nodes sharing this node's map coordinate (incl. itself), in globe ring order. */
@@ -102,6 +103,8 @@ export function NodeDetailPanel({
   onClose: () => void;
   /** Hide the provision/download action (e.g. on the public landing map). */
   showAction?: boolean;
+  /** Hide latency (e.g. on public landing map; keep for authenticated app). */
+  showLatency?: boolean;
 }) {
   useRelativeTimeTick();
   const online = node.status === "online" || node.status === "active";
@@ -237,7 +240,9 @@ export function NodeDetailPanel({
 
       {/* Key metrics */}
       <div className="mt-2 grid grid-cols-2 gap-1.5">
-        <Stat label="Latency" value={formatLatency(node.latency_ms)} color={latencyColor(node.latency_ms)} />
+        {showLatency && (
+          <Stat label="Latency" value={formatLatency(node.latency_ms)} color={latencyColor(node.latency_ms)} />
+        )}
         <Stat
           label="Load"
           value={node.load_pct != null ? `${node.load_pct.toFixed(0)}%` : "—"}

--- a/src/components/v3/marketing/LandingNetworkPreview.tsx
+++ b/src/components/v3/marketing/LandingNetworkPreview.tsx
@@ -6,7 +6,6 @@ import { NodeDetailPanel } from "@/components/v3/app/NodeDetailPanel";
 import { useOnlineNodes } from "@/context/online-nodes";
 import { coLocatedNodes } from "@/lib/globe-nodes";
 import { uniqueCountries } from "@/lib/regions";
-import { formatLatency } from "@/lib/format";
 
 export function LandingNetworkPreview() {
   const { nodes } = useOnlineNodes();
@@ -20,11 +19,6 @@ export function LandingNetworkPreview() {
   const detailNode = useMemo(
     () => (detailId ? (nodes.find((n) => n.id === detailId) ?? null) : null),
     [detailId, nodes],
-  );
-
-  const bestLatency = useMemo(
-    () => nodes.filter((n) => n.latency_ms != null).sort((a, b) => a.latency_ms! - b.latency_ms!)[0]?.latency_ms,
-    [nodes]
   );
 
   const handleSelect = useCallback((id: string) => {
@@ -66,7 +60,6 @@ export function LandingNetworkPreview() {
         <div className="pointer-events-none absolute bottom-5 left-5 flex gap-6">
           <Stat value={nodes.length} label="Nodes online" />
           <Stat value={uniqueCountries(nodes) || "—"} label="Regions" />
-          <Stat value={formatLatency(bestLatency)} label="Best latency" />
         </div>
 
         {detailNode && (
@@ -75,6 +68,7 @@ export function LandingNetworkPreview() {
             siblings={coLocatedNodes(nodes, detailNode)}
             onSelectSibling={handleSelect}
             showAction={false}
+            showLatency={false}
             onClose={() => setDetailId(null)}
           />
         )}

--- a/src/components/v3/marketing/OrgPublicPanel.tsx
+++ b/src/components/v3/marketing/OrgPublicPanel.tsx
@@ -4,7 +4,6 @@ import { fetchNodes, fetchPublicOrgProfile } from "@/lib/gateway/client";
 import { MarketingNav } from "@/components/v3/marketing/MarketingNav";
 import { MarketingFooter } from "@/components/v3/marketing/MarketingFooter";
 import { AccentButton, Card, Eyebrow, MonoLabel } from "@/components/v3/ui";
-import { formatLatency, latencyColor } from "@/lib/format";
 import { notFound } from "next/navigation";
 
 export async function OrgPublicPanel({ slug }: { slug: string }) {
@@ -154,11 +153,6 @@ export async function OrgPublicPanel({ slug }: { slug: string }) {
                     {typeof node.load_pct === "number" && (
                       <span className="font-mono text-[11px] text-[var(--text-3)]">
                         {Math.round(node.load_pct)}% load
-                      </span>
-                    )}
-                    {node.latency_ms != null && (
-                      <span className="font-mono text-[11px]" style={{ color: latencyColor(node.latency_ms) }}>
-                        {formatLatency(node.latency_ms)}
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
- Remove latency from public org node list (OrgPublicPanel)
- Remove 'Best latency' stat from landing network preview
- Add showLatency prop to NodeDetailPanel to hide latency in public contexts
- Keep latency display in authenticated contexts (VpnConnectPanel, NodeDetailPanel)