### PR TITLE
chore: align webapp with simplified Docker-only node contract

### DIFF
--- a/src/app/s/[fileId]/page.tsx
+++ b/src/app/s/[fileId]/page.tsx
@@ -3,11 +3,11 @@
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
-import { Download, ExternalLink, File, ShieldCheck } from "lucide-react";
+import { Download, File, ShieldCheck } from "lucide-react";
 import { toast } from "sonner";
 import { AuroraBackground } from "@/components/v3/AuroraBackground";
 import { AccentButton, Card, MonoLabel } from "@/components/v3/ui";
-import { directGatewayUrl, fetchPublicDropFile } from "@/lib/drop/client";
+import { fetchPublicDropFile } from "@/lib/drop/client";
 import { downloadPublicRef } from "@/lib/drop/download";
 import { formatBytes } from "@/lib/format";
 import type { DropPublicFile } from "@/lib/drop/types";
@@ -74,26 +74,6 @@ export default function PublicDropSharePage() {
               <Download size={15} />
               {downloading ? "Downloading…" : "Download"}
             </AccentButton>
-
-            {(() => {
-              const gatewayLink = directGatewayUrl(
-                file.gateway_url ?? file.gateway_urls?.[0],
-                file.cid
-              );
-              return gatewayLink ? (
-                <a
-                  href={gatewayLink}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="mt-2 block"
-                >
-                  <AccentButton variant="ghost" className="w-full">
-                    <ExternalLink size={15} />
-                    Open on IPFS gateway
-                  </AccentButton>
-                </a>
-              ) : null;
-            })()}
             <div className="mt-4 flex gap-2 text-xs leading-relaxed text-[var(--text-3)]">
               <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-[var(--accent-hi)]" />
               Public Drop files are plaintext. Anyone with this opaque link may download

--- a/src/components/v3/drop/DropFileList.tsx
+++ b/src/components/v3/drop/DropFileList.tsx
@@ -4,8 +4,7 @@ import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { Card, ActionButton } from "@/components/v3/ui";
 import { formatBytes, formatRelativeTime } from "@/lib/format";
-import { Download, Trash2, Copy, Share2, Lock, Globe, Check, ExternalLink } from "lucide-react";
-import { directGatewayUrl } from "@/lib/drop/client";
+import { Download, Trash2, Copy, Share2, Lock, Globe, Check } from "lucide-react";
 import type { DropFile, DropFileStatus } from "@/lib/drop/types";
 
 const STATUS_META: Record<
@@ -67,12 +66,6 @@ export function DropFileList({
             const canDownload =
               file.status === "available" && (!file.encrypted || file.can_decrypt);
             const busy = busyId === file.id;
-            // Optional direct node-gateway link, only for public files whose
-            // host exposes a public IPFS gateway.
-            const gatewayLink =
-              file.visibility === "public" && file.status === "available"
-                ? directGatewayUrl(file.gateway_url ?? file.gateway_urls?.[0], file.cid)
-                : null;
             return (
               <li key={file.id} className="flex flex-wrap items-center gap-3 px-5 py-3.5">
                 <div className="flex min-w-0 flex-1 items-center gap-3">
@@ -134,20 +127,6 @@ export function DropFileList({
                       <Share2 size={13} />
                       Share
                     </ActionButton>
-                  )}
-                  {gatewayLink && (
-                    <a
-                      href={gatewayLink}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="contents"
-                      aria-label={`Open ${file.filename} on the node IPFS gateway`}
-                    >
-                      <ActionButton variant="neutral">
-                        <ExternalLink size={13} />
-                        Gateway
-                      </ActionButton>
-                    </a>
                   )}
                   <ActionButton
                     variant="accent"

--- a/src/components/v3/drop/DropNodePicker.tsx
+++ b/src/components/v3/drop/DropNodePicker.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Globe, GlobeLock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Card, MonoLabel, StatusDot } from "@/components/v3/ui";
 import type { DropNode } from "@/lib/drop/types";
@@ -77,33 +76,6 @@ export function DropNodePicker({
                       )}
                     >
                       {node.scope}
-                    </span>
-                    <span
-                      title={
-                        node.gateway_available
-                          ? `This node publishes its IPFS gateway over HTTPS${
-                              node.gateway_url ? ` (${node.gateway_url})` : ""
-                            } — files can be viewed directly in the browser by CID.`
-                          : "This node has not published a public gateway — files are served through the Erebrus gateway proxy only."
-                      }
-                      className={cn(
-                        "flex items-center gap-1 rounded px-1.5 font-mono text-[10px]",
-                        node.gateway_available
-                          ? "bg-[var(--success)]/15 text-[var(--success)]"
-                          : "bg-white/[0.06] text-[var(--text-3)]"
-                      )}
-                    >
-                      {node.gateway_available ? (
-                        <>
-                          <Globe size={10} />
-                          direct view
-                        </>
-                      ) : (
-                        <>
-                          <GlobeLock size={10} />
-                          proxy only
-                        </>
-                      )}
                     </span>
                   </div>
                   <div className="mt-0.5 truncate font-mono text-[11px] text-[var(--text-3)]">

--- a/src/lib/drop/client.ts
+++ b/src/lib/drop/client.ts
@@ -254,55 +254,19 @@ export function publicDropContentUrl(fileId: string): string {
   return dropUrl(`drop/public/${fileId}/content`);
 }
 
-/**
- * Build a direct node IPFS gateway URL (`{gateway}/ipfs/{cid}`) for a file's
- * CID. Nodes publish their gateway as an HTTPS domain, so a non-HTTPS or
- * malformed base (or the RPC endpoint) is rejected — an insecure link is never
- * produced. A CID is content-addressed, so any node gateway that has pinned it
- * can serve identical bytes, enabling cross-node fallback.
- */
-export function directGatewayUrl(
-  gatewayBase: string | undefined,
-  cid: string | undefined
-): string | null {
-  if (!gatewayBase || !cid) return null;
-  try {
-    const url = new URL(gatewayBase);
-    if (url.protocol !== "https:" || !url.hostname || url.port === "5001") return null;
-    const base = gatewayBase.replace(/\/+$/, "");
-    return `${base}/ipfs/${encodeURIComponent(cid)}`;
-  } catch {
-    return null;
-  }
-}
-
 /** Minimal shape needed to resolve a public file's content sources. */
 export interface PublicContentRef {
   id: string;
-  cid?: string;
-  gateway_url?: string;
-  gateway_urls?: string[];
 }
 
 /**
- * Ordered content sources for a public file. Direct node IPFS gateways come
- * first (fast, offloads the Erebrus gateway), followed by the Erebrus gateway
- * proxy as the durable fallback — the proxy can source the same CID from any
- * node that has it pinned, so a single downed node doesn't break retrieval.
+ * Content source for a public file. Nodes no longer advertise a public IPFS
+ * gateway base, so all public content is served through the same-origin Erebrus
+ * gateway proxy. The proxy can source the same CID from any node that has it
+ * pinned, so a single downed node doesn't break retrieval.
  */
 export function publicContentSources(file: PublicContentRef): string[] {
-  const sources: string[] = [];
-  const bases = [
-    ...(file.gateway_urls ?? []),
-    ...(file.gateway_url ? [file.gateway_url] : []),
-  ];
-  for (const base of bases) {
-    const url = directGatewayUrl(base, file.cid);
-    if (url && !sources.includes(url)) sources.push(url);
-  }
-  const proxy = publicDropContentUrl(file.id);
-  if (!sources.includes(proxy)) sources.push(proxy);
-  return sources;
+  return [publicDropContentUrl(file.id)];
 }
 
 // ── Private node WebUI ──────────────────────────────────────────────────────

--- a/src/lib/drop/download.ts
+++ b/src/lib/drop/download.ts
@@ -10,10 +10,10 @@ import type { DropFile } from "./types";
 export type DecryptContent = (file: DropFile, ciphertext: ArrayBuffer) => Promise<Blob>;
 
 /**
- * Fetch a file's content. Public files try each source in order (direct node
- * IPFS gateways first, then the Erebrus gateway proxy) so a downed node doesn't
- * break retrieval — the same CID is served by any node that has it pinned.
- * Encrypted/private files stream from the authenticated gateway proxy.
+ * Fetch a file's content. Public files stream from the same-origin Erebrus
+ * gateway proxy, which can source the same CID from any pinned node so a
+ * downed node doesn't break retrieval. Encrypted/private files stream from
+ * the authenticated gateway proxy.
  */
 async function fetchContentWithFallback(
   file: DropFile,
@@ -89,9 +89,8 @@ export async function downloadDropFile(
 }
 
 /**
- * Download a public file from the opaque share page, trying each content source
- * in order (direct node gateways first, then the Erebrus gateway proxy) until
- * one succeeds. Tolerates a downed node since the CID is content-addressed.
+ * Download a public file from the opaque share page through the Erebrus gateway
+ * proxy. Tolerates a downed node since the CID is content-addressed.
  */
 export async function downloadPublicRef(
   file: PublicContentRef & { filename: string; content_type: string },

--- a/src/lib/drop/normalize.test.ts
+++ b/src/lib/drop/normalize.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   normalizeDropFile,
   normalizeDropNode,
+  normalizeDropPublicFile,
   normalizeDropUpload,
   normalizeDropUsage,
   normalizeDropEncryptionMetadata,
@@ -32,55 +33,16 @@ describe("normalizeDropNode", () => {
     expect(node.accepting).toBe(false);
   });
 
-  it("defaults gateway_available to false when the node publishes no gateway domain", () => {
-    const node = normalizeDropNode({ id: "n" });
-    expect(node.gateway_available).toBe(false);
-    expect(node.gateway_url).toBeUndefined();
-  });
-
-  it("reads the HTTPS gateway domain from public_gateway_url and the drop capability", () => {
-    const top = normalizeDropNode({ id: "n", public_gateway_url: "https://drop-sg1.erebrus.io" });
-    expect(top.gateway_available).toBe(true);
-    expect(top.gateway_url).toBe("https://drop-sg1.erebrus.io");
-
-    const nested = normalizeDropNode({
+  it("derives webui_available from the drop capability", () => {
+    const node = normalizeDropNode({
       id: "n",
-      capabilities: { drop: { public_gateway_url: "https://drop-sg1.erebrus.io/" } },
+      capabilities: { drop: { webui_available: true } },
     });
-    expect(nested.gateway_available).toBe(true);
-    expect(nested.gateway_url).toBe("https://drop-sg1.erebrus.io");
-  });
-
-  it("rejects non-HTTPS and RPC gateway values so no insecure link reaches the UI", () => {
-    expect(normalizeDropNode({ id: "n", public_gateway_url: "http://node1.example" }).gateway_available).toBe(false);
-    expect(normalizeDropNode({ id: "n", public_gateway_url: "https://node1.example:5001" }).gateway_available).toBe(false);
-    expect(normalizeDropNode({ id: "n", public_gateway_url: "not-a-url" }).gateway_url).toBeUndefined();
+    expect(node.webui_available).toBe(true);
   });
 });
 
 describe("normalizeDropFile", () => {
-  it("keeps only valid HTTPS gateway bases and drops http/invalid entries", () => {
-    const file = normalizeDropFile({
-      file_id: "f1",
-      gateway_url: "https://node1.example/",
-      gateway_urls: [
-        "https://node2.example",
-        "http://insecure.example",
-        "",
-        123,
-        "https://node3.example/",
-      ],
-    });
-    expect(file.gateway_url).toBe("https://node1.example");
-    expect(file.gateway_urls).toEqual(["https://node2.example", "https://node3.example"]);
-  });
-
-  it("leaves gateway fields undefined when absent", () => {
-    const file = normalizeDropFile({ file_id: "f1" });
-    expect(file.gateway_url).toBeUndefined();
-    expect(file.gateway_urls).toBeUndefined();
-  });
-
   it("defaults visibility to private and status to reserved", () => {
     const file = normalizeDropFile({ file_id: "f1", filename: "a.bin", size_bytes: 10 });
     expect(file.id).toBe("f1");
@@ -101,6 +63,16 @@ describe("normalizeDropFile", () => {
     expect(file.status).toBe("available");
     expect(file.encrypted).toBe(true);
     expect(file.cid).toBe("bafy");
+  });
+});
+
+describe("normalizeDropPublicFile", () => {
+  it("exposes the gateway proxy content_url", () => {
+    const file = normalizeDropPublicFile({
+      file_id: "f1",
+      content_url: "/api/v2/drop/public/f1/content",
+    });
+    expect(file.content_url).toBe("/api/v2/drop/public/f1/content");
   });
 });
 

--- a/src/lib/drop/normalize.ts
+++ b/src/lib/drop/normalize.ts
@@ -28,36 +28,6 @@ function bool(v: unknown): boolean {
   return v === true || v === "true";
 }
 
-/**
- * Validate and normalize a public IPFS gateway base. Nodes advertise their
- * gateway as an HTTPS domain (TLS-terminating reverse proxy in front of Kubo
- * 8080), so only `https://host` bases are accepted — any `http`, missing host,
- * or malformed value is rejected so an insecure link can never reach the UI.
- * The trailing slash is trimmed; the RPC endpoint (`:5001`) is refused.
- */
-function httpsGatewayBase(v: unknown): string | undefined {
-  const s = str(v);
-  if (!s) return undefined;
-  try {
-    const url = new URL(s);
-    if (url.protocol !== "https:" || !url.hostname) return undefined;
-    if (url.port === "5001") return undefined;
-    return s.replace(/\/+$/, "");
-  } catch {
-    return undefined;
-  }
-}
-
-function httpsGatewayBases(v: unknown): string[] | undefined {
-  if (!Array.isArray(v)) return undefined;
-  const out: string[] = [];
-  for (const item of v) {
-    const base = httpsGatewayBase(item);
-    if (base && !out.includes(base)) out.push(base);
-  }
-  return out.length ? out : undefined;
-}
-
 function scope(v: unknown): DropScope {
   return String(v ?? "").toLowerCase() === "public" ? "public" : "private";
 }
@@ -115,13 +85,6 @@ export function normalizeDropNode(raw: Raw): DropNode {
     raw.capabilities && typeof raw.capabilities === "object"
       ? ((raw.capabilities as Raw).drop as Raw | undefined)
       : undefined;
-  // A node exposes its gateway purely by advertising an HTTPS domain in
-  // `public_gateway_url` (empty means unpublished). There is no separate boolean
-  // toggle: availability is derived solely from a valid HTTPS base being present.
-  const gatewayUrl = httpsGatewayBase(
-    raw.public_gateway_url ?? dropCap?.public_gateway_url ?? raw.gateway_url
-  );
-  const gatewayAvailable = !!gatewayUrl;
   return {
     id: String(raw.node_id ?? raw.id ?? ""),
     name: str(raw.name) ?? String(raw.node_id ?? raw.id ?? "node"),
@@ -138,8 +101,6 @@ export function normalizeDropNode(raw: Raw): DropNode {
         ? raw.accepting !== false
         : bool(raw.accepting_uploads),
     webui_available: bool(raw.webui_available ?? dropCap?.webui_available),
-    gateway_available: gatewayAvailable,
-    gateway_url: gatewayUrl,
   };
 }
 
@@ -160,8 +121,6 @@ export function normalizeDropFile(raw: Raw): DropFile {
     created_at: str(raw.created_at),
     updated_at: str(raw.updated_at),
     encryption_metadata: normalizeDropEncryptionMetadata(raw.encryption_metadata),
-    gateway_url: httpsGatewayBase(raw.gateway_url ?? raw.public_gateway_url),
-    gateway_urls: httpsGatewayBases(raw.gateway_urls ?? raw.public_gateway_urls),
   };
 }
 
@@ -198,8 +157,7 @@ export function normalizeDropPublicFile(raw: Raw): DropPublicFile {
     size_bytes: num(raw.size_bytes ?? raw.size),
     cid: str(raw.cid),
     created_at: str(raw.created_at),
-    gateway_url: httpsGatewayBase(raw.gateway_url ?? raw.public_gateway_url),
-    gateway_urls: httpsGatewayBases(raw.gateway_urls ?? raw.public_gateway_urls),
+    content_url: str(raw.content_url),
   };
 }
 

--- a/src/lib/drop/types.ts
+++ b/src/lib/drop/types.ts
@@ -30,20 +30,8 @@ export interface DropNode {
   capacity: DropNodeCapacity;
   /** False when the node is not currently accepting new pins. */
   accepting: boolean;
+  /** True when the node has a same-origin WebUI proxy for Kubo. */
   webui_available: boolean;
-  /**
-   * True when the operator has published this node's public IPFS gateway under
-   * an HTTPS domain, enabling direct in-browser file viewing by CID. Derived
-   * solely from a valid `gateway_url`; when false, content is only reachable
-   * through the Erebrus gateway proxy.
-   */
-  gateway_available: boolean;
-  /**
-   * The node's public IPFS gateway base — always an HTTPS domain
-   * (e.g. `https://drop-sg1.erebrus.io`) that TLS-terminates in front of Kubo.
-   * Present only when the operator has published it.
-   */
-  gateway_url?: string;
 }
 
 /**
@@ -89,13 +77,6 @@ export interface DropFile {
   created_at?: string;
   updated_at?: string;
   encryption_metadata?: DropEncryptionMetadata;
-  /** Direct public IPFS gateway base for the hosting node, when exposed. */
-  gateway_url?: string;
-  /**
-   * Additional public gateway bases for other nodes that have pinned this CID.
-   * Used to fall back across nodes if one is down (content is addressed by CID).
-   */
-  gateway_urls?: string[];
 }
 
 /** Per-user (public) or per-org (private) storage accounting. */
@@ -145,10 +126,8 @@ export interface DropPublicFile {
   size_bytes: number;
   cid?: string;
   created_at?: string;
-  /** Direct public IPFS gateway base for the hosting node, when exposed. */
-  gateway_url?: string;
-  /** Additional gateway bases for other nodes pinning this CID (fallback). */
-  gateway_urls?: string[];
+  /** Same-origin gateway proxy URL for downloading the public file. */
+  content_url?: string;
 }
 
 /** Short-lived same-origin proxy session for a private node's Kubo WebUI. */

--- a/src/lib/gateway/normalize.ts
+++ b/src/lib/gateway/normalize.ts
@@ -40,13 +40,9 @@ function normalizeNodeOrg(raw: unknown): GatewayNodeOrgSummary | undefined {
 function normalizeCapabilities(raw: unknown): GatewayNodeCapabilities | undefined {
   if (!raw || typeof raw !== "object") return undefined;
   const caps = raw as Record<string, unknown>;
-  const out: GatewayNodeCapabilities = {};
   const accessMode = optStr(caps.access_mode);
-  if (accessMode) out.access_mode = accessMode;
-  if (caps.app_hosting === true) out.app_hosting = true;
-  const wildcard = optStr(caps.wildcard_domain);
-  if (wildcard) out.wildcard_domain = wildcard;
-  return Object.keys(out).length > 0 ? out : undefined;
+  if (!accessMode) return undefined;
+  return { access_mode: accessMode };
 }
 
 export function normalizeNode(raw: Record<string, unknown>): GatewayNode {

--- a/src/lib/gateway/types.ts
+++ b/src/lib/gateway/types.ts
@@ -23,8 +23,6 @@ export interface GatewayNodeSpeedtest {
 /** Capability flags advertised by a node. */
 export interface GatewayNodeCapabilities {
   access_mode?: string;
-  app_hosting?: boolean;
-  wildcard_domain?: string;
 }
 
 /** WireGuard endpoint on a discovery node (dial host for client RTT probes). */


### PR DESCRIPTION
Remove public IPFS gateway fields and app_hosting/wildcard_domain from Drop and gateway models. Public Drop content now flows through the same-origin Erebrus gateway proxy.