### PR TITLE
refactor(footer,legal): move account deletion link into terms and pri…

### DIFF
--- a/src/app/(marketing)/privacy/page.tsx
+++ b/src/app/(marketing)/privacy/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { pageMetadata } from "@/lib/seo";
 import {
   LegalPageShell,
@@ -256,6 +257,32 @@ export default function PrivacyPage() {
         {sections.map((section) => (
           <LegalSection key={section.title} {...section} />
         ))}
+
+        <section className="rounded-2xl border border-white/[0.07] bg-white/[0.02] p-6">
+          <h2 className="mb-4 text-xl font-semibold tracking-tight md:text-2xl">
+            Account deletion
+          </h2>
+          <p className="mb-4 leading-7 text-[var(--text-2)]">
+            You can request deletion of your Erebrus account and the personal data associated with it. Read the{" "}
+            <Link
+              href="/account-deletion"
+              className="text-[var(--accent-hi)] hover:underline"
+            >
+              account deletion page
+            </Link>{" "}
+            for what is deleted, what may be retained, and how to verify ownership.
+          </p>
+          <p className="leading-7 text-[var(--text-2)]">
+            If you can sign in, request deletion from your Profile. If you cannot sign in, use the{" "}
+            <Link
+              href="/contact?category=account-deletion"
+              className="text-[var(--accent-hi)] hover:underline"
+            >
+              contact form
+            </Link>{" "}
+            with the “Account deletion” category.
+          </p>
+        </section>
       </div>
     </LegalPageShell>
   );

--- a/src/app/(marketing)/terms/page.tsx
+++ b/src/app/(marketing)/terms/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { pageMetadata } from "@/lib/seo";
 import {
   LegalPageShell,
@@ -227,6 +228,32 @@ export default function TermsPage() {
         {sections.map((section) => (
           <LegalSection key={section.title} {...section} />
         ))}
+
+        <section className="rounded-2xl border border-white/[0.07] bg-white/[0.02] p-6">
+          <h2 className="mb-4 text-xl font-semibold tracking-tight md:text-2xl">
+            Account deletion
+          </h2>
+          <p className="mb-4 leading-7 text-[var(--text-2)]">
+            You can request deletion of your Erebrus account and associated data at any time. Read the{" "}
+            <Link
+              href="/account-deletion"
+              className="text-[var(--accent-hi)] hover:underline"
+            >
+              account deletion page
+            </Link>{" "}
+            for what is deleted, what may be retained, and how to verify ownership.
+          </p>
+          <p className="leading-7 text-[var(--text-2)]">
+            If you can sign in, request deletion from your Profile. If you cannot sign in, use the{" "}
+            <Link
+              href="/contact?category=account-deletion"
+              className="text-[var(--accent-hi)] hover:underline"
+            >
+              contact form
+            </Link>{" "}
+            with the “Account deletion” category.
+          </p>
+        </section>
       </div>
     </LegalPageShell>
   );

--- a/src/components/v3/marketing/MarketingFooter.tsx
+++ b/src/components/v3/marketing/MarketingFooter.tsx
@@ -30,7 +30,6 @@ const legalLinks = [
   { href: "/privacy", label: "Privacy" },
   { href: "/terms", label: "Terms" },
   { href: "/contact", label: "Contact" },
-  { href: "/account-deletion", label: "Account deletion" },
 ];
 
 export function MarketingFooter() {


### PR DESCRIPTION
…vacy

- Remove Account deletion from MarketingFooter legal links.
- Add an Account deletion section to /terms and /privacy linking to /account-deletion and /contact.